### PR TITLE
Add design and POC implementation for consensus app

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,35 @@
+# Consensus App Design
+
+## Overview
+The app lets a user query an AI model multiple times with the same question,
+collect the answers, and generate a short summary of the consensus and its
+strength. It supports both OpenAI's API and the OpenRouter API (which mirrors
+the OpenAI API scheme) so users can experiment with different models and
+providers.
+
+## Components
+1. **Frontend** (static web page)
+   - Form fields for API key, provider (OpenAI/OpenRouter), model name,
+     question, and number of repetitions.
+   - Fetches results from a backend endpoint and displays individual answers and
+the consensus summary.
+
+2. **Backend** (Node + Express)
+   - `POST /ask` receives the API key, provider, model, question and the number
+     of times to ask.
+   - Calls the provider API repeatedly and stores each answer.
+   - Calls the provider once more to summarise the list of answers (prompting the
+     model to judge consensus and strength).
+   - Returns the array of answers and the summary to the frontend.
+
+## Deployment considerations
+OpenAI's API does not allow CORS requests directly from the browser, so a pure
+GitHub Pages site cannot call it without a server. The backend can be hosted on
+a low‑maintenance platform such as Vercel, Deno Deploy or Cloudflare Workers.
+The frontend (static files) can still live on GitHub Pages.
+
+## First-phase POC
+- Minimal Node/Express backend acting as a proxy and aggregation layer.
+- Simple HTML+JS frontend.
+- No persistence or authentication beyond the supplied API key.
+- Summarisation uses the same provider/model as the main requests.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "consensus-app",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Consensus App</title>
+</head>
+<body>
+<h1>Consensus App</h1>
+<form id="ask-form">
+  <label>API Key: <input type="password" id="apiKey" required></label><br/>
+  <label>Provider:
+    <select id="provider">
+      <option value="openai">OpenAI</option>
+      <option value="openrouter">OpenRouter</option>
+    </select>
+  </label><br/>
+  <label>Model: <input type="text" id="model" value="gpt-3.5-turbo" required></label><br/>
+  <label>Question: <input type="text" id="question" required></label><br/>
+  <label>Count: <input type="number" id="count" value="10" min="1" max="20"></label><br/>
+  <button type="submit">Ask</button>
+</form>
+<pre id="output"></pre>
+<script type="module" src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,30 @@
+const form = document.getElementById('ask-form');
+const output = document.getElementById('output');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  output.textContent = 'Querying...';
+  const body = {
+    apiKey: document.getElementById('apiKey').value,
+    provider: document.getElementById('provider').value,
+    model: document.getElementById('model').value,
+    question: document.getElementById('question').value,
+    count: parseInt(document.getElementById('count').value, 10)
+  };
+
+  const res = await fetch('/ask', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+
+  if (!res.ok) {
+    const t = await res.text();
+    output.textContent = 'Error: ' + t;
+    return;
+  }
+
+  const data = await res.json();
+  output.textContent = data.answers.map((a,i)=>`Answer ${i+1}: ${a}`).join('\n\n') +
+    '\n\nConsensus Summary:\n' + data.summary;
+});

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,19 @@
-Initial content.
+# Consensus App POC
+
+This repository contains a small proof of concept for querying an AI model
+multiple times and summarising the consensus among the answers.
+
+## Running locally
+1. Install Node.js (18+).
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the server:
+   ```bash
+   npm start
+   ```
+4. Open `http://localhost:3000` in your browser.
+
+Enter your API key, provider, model, question and how many times to ask. The
+app will display each answer and a summary of the consensus.

--- a/server.js
+++ b/server.js
@@ -1,0 +1,66 @@
+import express from 'express';
+import fetch from 'node-fetch';
+
+const app = express();
+app.use(express.json());
+app.use(express.static("public"));
+
+function providerUrl(provider) {
+  return provider === 'openrouter'
+    ? 'https://openrouter.ai/api/v1/chat/completions'
+    : 'https://api.openai.com/v1/chat/completions';
+}
+
+app.post('/ask', async (req, res) => {
+  try {
+    const { apiKey, provider, model, question, count } = req.body;
+    if (!apiKey || !question || !model) {
+      return res.status(400).json({ error: 'Missing parameters' });
+    }
+    const url = providerUrl(provider);
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    };
+
+    const answers = [];
+    for (let i = 0; i < (count || 10); i++) {
+      const body = {
+        model,
+        messages: [{ role: 'user', content: question }],
+      };
+      const resp = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+      if (!resp.ok) {
+        const text = await resp.text();
+        return res.status(resp.status).json({ error: text });
+      }
+      const data = await resp.json();
+      const answer = data.choices?.[0]?.message?.content || '';
+      answers.push(answer.trim());
+    }
+
+    // Summarize consensus
+    const summarizationPrompt = `Given the following answers, summarize any consensus and how strong it is:\n\n${answers.map((a,i)=>`${i+1}. ${a}`).join('\n')}\n`;
+    const summaryBody = {
+      model,
+      messages: [
+        { role: 'system', content: 'You summarize repeated answers.' },
+        { role: 'user', content: summarizationPrompt },
+      ],
+    };
+    const summaryResp = await fetch(url, { method: 'POST', headers, body: JSON.stringify(summaryBody) });
+    let summary = '';
+    if (summaryResp.ok) {
+      const sdata = await summaryResp.json();
+      summary = sdata.choices?.[0]?.message?.content || '';
+    }
+
+    res.json({ answers, summary });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Server running on ${port}`));


### PR DESCRIPTION
## Summary
- document design goals and deployment approach
- create basic Node/Express server with `/ask` endpoint
- add simple HTML/JS frontend
- update README with local usage instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844601586f883269c43b05fd6416756